### PR TITLE
Fix worker path and add test script

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -38,7 +38,7 @@ let startOffsetY = 0;
 // Initialize Web Worker only once with error handling
 let worker;
 try {
-    worker = new Worker("mandelbrotWorker.js");
+    worker = new Worker("MandelbrotWorker.js");
 } catch (err) {
     console.error("Web Worker initialization failed:", err);
     const errorDiv = document.getElementById("workerError");

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "MandelbrotWorker.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node MandelbrotWorker.test.js",
     "format": "prettier --write \"**/*.{js,css,html}\""
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- fix case mismatch for the Web Worker file in `Script.js`
- run `MandelbrotWorker.test.js` through the npm test script

## Testing
- `npm test`


