### PR TITLE
Fix worker path and add dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Mandelbrot Visualizer
+
+This project renders the Mandelbrot set using a Web Worker for computation.
+
+## Development
+
+Install dependencies (only Prettier is required for formatting):
+
+```bash
+npm install
+```
+
+Start a local server:
+
+```bash
+npm start
+```
+
+Run tests:
+
+```bash
+npm test
+```
+
+Open `http://localhost:8080` in your browser to view the app.

--- a/Script.js
+++ b/Script.js
@@ -38,7 +38,7 @@ let startOffsetY = 0;
 // Initialize Web Worker only once with error handling
 let worker;
 try {
-    worker = new Worker("mandelbrotWorker.js");
+    worker = new Worker("MandelbrotWorker.js");
 } catch (err) {
     console.error("Web Worker initialization failed:", err);
     const errorDiv = document.getElementById("workerError");

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "",
   "main": "MandelbrotWorker.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "format": "prettier --write \"**/*.{js,css,html}\""
+    "test": "node MandelbrotWorker.test.js",
+    "format": "prettier --write \"**/*.{js,css,html}\"",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,29 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const root = __dirname;
+const port = process.env.PORT || 8080;
+
+http.createServer((req, res) => {
+  const reqPath = req.url === '/' ? '/Index.html' : req.url;
+  const filePath = path.join(root, reqPath);
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath).toLowerCase();
+    const type = {
+      '.html': 'text/html',
+      '.js': 'text/javascript',
+      '.css': 'text/css',
+      '.json': 'application/json'
+    }[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+}).listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- fix case mismatch for the Web Worker file in `Script.js`
- run `MandelbrotWorker.test.js` through the npm test script
- add a lightweight Node static server and npm start command
- document project usage in README

## Testing
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857bb34b1c88333b2ae0bbce22aa416